### PR TITLE
Make 'xwalk_application_lib' target explicitly depend on 'events.gyp:events'

### DIFF
--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -45,6 +45,7 @@
             'build/system.gyp:tizen_appcore_common',
             'tizen/xwalk_tizen.gypi:xwalk_tizen_lib',
             '<(DEPTH)/ui/events/platform/events_platform.gyp:events_platform',
+            '<(DEPTH)/ui/events/events.gyp:events',
           ],
           'sources': [
             'browser/application_tizen.cc',


### PR DESCRIPTION
This fixes the following error, when building with crosswalk-bin.spec:

[XXs] xwalk/application/browser/application_tizen.cc:317:
  error: undefined reference to 'ui::EventFromNative(void\* const&)'
