### PR TITLE
Make it possible to link crosswalk against libchromium-ewk.so

### DIFF
--- a/application/common/xwalk_application_common.gypi
+++ b/application/common/xwalk_application_common.gypi
@@ -1,4 +1,7 @@
 {
+'variables': {
+  'external_xwalk_application_common_lib_dependencies_removals%': [],
+},
 'targets': [
     {
       'target_name': 'xwalk_application_common_lib',
@@ -108,6 +111,9 @@
         '../..',
         '../../..',
       ],
+      'dependencies!' : [
+        '<@(external_xwalk_application_common_lib_dependencies_removals)',
+      ]
     },
   ],
 }

--- a/application/tools/tizen/xwalk_tizen_tools.gyp
+++ b/application/tools/tizen/xwalk_tizen_tools.gyp
@@ -9,6 +9,7 @@
         '../../../build/system.gyp:gio',
         '../../../build/system.gyp:tizen',
         '../../../build/system.gyp:tizen_tzplatform_config',
+        '<@(external_chromium_ewk_dependency)',
       ],
       'include_dirs': [
         '../../../..',
@@ -42,6 +43,7 @@
         '../../../build/system.gyp:tizen',
         '../../../../base/base.gyp:base',
         '../../common/xwalk_application_common.gypi:xwalk_application_common_lib',
+        '<@(external_chromium_ewk_dependency)',
       ],
       'include_dirs': [
         '../../../..',

--- a/application/xwalk_application.gypi
+++ b/application/xwalk_application.gypi
@@ -1,4 +1,7 @@
 {
+'variables': {
+  'external_xwalk_application_lib_dependencies_removals%': [],
+},
 'targets': [
     {
       'target_name': 'xwalk_application_lib',
@@ -66,6 +69,9 @@
         '..',
         '../..',
       ],
+      'dependencies!' : [
+        '<@(external_xwalk_application_lib_dependencies_removals)',
+      ]
     },
 
     {

--- a/extensions/extensions.gyp
+++ b/extensions/extensions.gyp
@@ -1,4 +1,7 @@
 {
+  'variables': {
+    'external_xwalk_extensions_dependencies_removals%': [],
+  },
   'targets': [
     {
       'target_name': 'xwalk_extensions',
@@ -69,6 +72,9 @@
         'renderer/xwalk_v8tools_module.cc',
         'renderer/xwalk_v8tools_module.h',
       ],
+      'dependencies!' : [
+        '<@(external_xwalk_extensions_dependencies_removals)',
+      ]
     },
   ],
 }

--- a/sysapps/sysapps.gyp
+++ b/sysapps/sysapps.gyp
@@ -1,4 +1,7 @@
 {
+  'variables': {
+    'external_sysapps_dependencies_removals%': [],
+  },
   'targets': [
     {
       'target_name': 'sysapps',
@@ -93,6 +96,9 @@
           '<(SHARED_INTERMEDIATE_DIR)',
         ]
       },
+      'dependencies!' : [
+        '<@(external_sysapps_dependencies_removals)',
+      ]
     },
   ],
 }

--- a/tizen/xwalk_tizen.gypi
+++ b/tizen/xwalk_tizen.gypi
@@ -1,4 +1,7 @@
 {
+  'variables': {
+    'external_xwalk_tizen_lib_dependencies_removals%': [],
+  },
   'targets': [
   {
     'target_name': 'xwalk_tizen_lib',
@@ -42,5 +45,8 @@
         ],
       }],
     ],
+    'dependencies!' : [
+      '<@(external_xwalk_tizen_lib_dependencies_removals)',
+    ]
   }],
 }

--- a/xwalk.gyp
+++ b/xwalk.gyp
@@ -12,6 +12,9 @@
         'enable_extensions': 1,
       }],
     ], # conditions
+    'external_xwalk_dependencies_removals%': [],
+    'external_xwalk_runtime_dependencies_removals%': [],
+    'external_chromium_ewk_dependency%': [],
   },
   'includes' : [
     'xwalk_tests.gypi',
@@ -470,6 +473,9 @@
           ],
         }],
       ],
+      'dependencies!' : [
+        '<@(external_xwalk_runtime_dependencies_removals)',
+      ]
     },
     {
       'target_name': 'generate_upstream_blink_version',
@@ -620,6 +626,7 @@
       'dependencies': [
         'xwalk_runtime',
         'xwalk_pak',
+        '<@(external_chromium_ewk_dependency)',
       ],
       'include_dirs': [
         '..',
@@ -746,6 +753,9 @@
           ],
         }],  # OS=="mac"
       ],
+      'dependencies!' : [
+        '<@(external_xwalk_dependencies_removals)',
+      ]
     },
     {
       'target_name': 'xwalk_builder',


### PR DESCRIPTION
As it is today, on regular chromium builds (i.e. non component-build),
'xwalk' (the binary) links against lots of static internal chromium
libs (.a files). That produces a large binary size (~90Mb).
This is because of the way targets' dependencies are set in crosswalk
GYP files.

Patch adds some GYP variables to act as placeholders, and then make
it possible to "remove" some dependencies set in crosswalk's GYP files.
Additionally, it allows 'xwalk' (the binary) to link against libchromium-ewk.so,
instead of again internal chromium libs.

We then remove duplicated symbols (in xwalk statically linked binary and
in libchromium-ewk.so), and reduce xwalk binary.
